### PR TITLE
adding ability to run tests in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 Vagrantfile
 playbook.yml
 *.retry
+results/
+parallel/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Under development or on the roadmap for development:
 - Open Vagrantfile in your favorite editor and review/edit the settings for your guest VM as needed (e.g. path to file system shares between the host and guest machines)
 - Open provisioning/playbook.yml in your favorite editor and review/edit the settings for your guest VM as needed
 - Next initialize and update the git submodules by running `git submodule init && git submodule update`, which will fetch the ansible-roles and client tools repositories
-- Export variable SMOKE_TESTS. This variable should be set to `kv` or `ts`
+- Export variable SMOKE_TESTS. This variable should be set to `kv` or `ts`. `export SMOKE_TESTS="kv"` or `export SMOKE_TESTS="ts"`
 - Run `vagrant up` to turn on your VM for the first time. It will automatically do the initial provisioning for the guest machine
 - After the machine has completed initial provisioning, login to it by running `vagrant ssh`
 - Once in the machine, run `ansible-playbook /vagrant/provisioning/playbook.yml` to install Riak (alternatively you can run timeseries.yml or security.yml to test TS or security instead)
@@ -42,3 +42,11 @@ Under development or on the roadmap for development:
 # Ansible Galaxy Riak role development
 
 If you want to contribute to the Ansible Riak role, clone the repository to `provisioning/roles/basho-labs.riak-kv.dev` and `riak_testing_role_dev: true` to your playbook.yml. This will tell signal to the Ansible roles to use the local checkout for playbook execution instead of the latest release to Ansible Galaxy.
+
+# Running tests in parallel
+- Open `multi-test.sh` and add your target vagrant boxes and Riak package URLs in the appropriate place
+- `export CT_GITHUB_TOKEN="put your github token here"`
+- `export SMOKE_TESTS="ts"` or `export SMOKE_TESTS="kv"`
+- `export CT_TEST_LIBS="['php','go', 'ruby', 'nodejs', 'java']"`
+- `export RIAK_TESTING_ROLE_DEV="true"`
+- `sh multi-test.sh`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ If you want to contribute to the Ansible Riak role, clone the repository to `pro
 - Open `multi-test.sh` and add your target vagrant boxes and Riak package URLs in the appropriate place
 - `export CT_GITHUB_TOKEN="put your github token here"`
 - `export SMOKE_TESTS="ts"` or `export SMOKE_TESTS="kv"`
-- `export CT_TEST_LIBS="['php','go', 'ruby', 'nodejs', 'java']"`
+- `export CT_TEST_LIBS="['php', 'go', 'ruby', 'nodejs', 'java']"`
 - `export RIAK_TESTING_ROLE_DEV="true"`
 - `sh multi-test.sh`

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you want to contribute to the Ansible Riak role, clone the repository to `pro
 - `export CT_GITHUB_TOKEN="put your github token here"`
 - `export SMOKE_TESTS="ts"` or `export SMOKE_TESTS="kv"`. If not exported, defaults to `kv`
 - `export CT_TEST_LIBS="['php', 'go', 'ruby', 'nodejs', 'java']"`
-- `export RIAK_TESTING_ROLE_DEV="true"`
+- Set concurrency limit, e.g. `export CONCURRENCY_LIMIT=1` for sequential runs or `export CONCURRENCY_LIMIT=3` for 3 VM's at a time
 - `sh multi-test.sh run`
 - After running the tests, you can clean up with `sh multi-test.sh cleanup`. This will shutdown all VMs and delete their directories. This will leave the test results in `./results`
 - Run `sh multi-test.sh reset` to delete all VM's and testing directories, including the `./results`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Under development or on the roadmap for development:
 - Open Vagrantfile in your favorite editor and review/edit the settings for your guest VM as needed (e.g. path to file system shares between the host and guest machines)
 - Open provisioning/playbook.yml in your favorite editor and review/edit the settings for your guest VM as needed
 - Next initialize and update the git submodules by running `git submodule init && git submodule update`, which will fetch the ansible-roles and client tools repositories
+- Export variable SMOKE_TESTS. This variable should be set to `kv` or `ts`
 - Run `vagrant up` to turn on your VM for the first time. It will automatically do the initial provisioning for the guest machine
 - After the machine has completed initial provisioning, login to it by running `vagrant ssh`
 - Once in the machine, run `ansible-playbook /vagrant/provisioning/playbook.yml` to install Riak (alternatively you can run timeseries.yml or security.yml to test TS or security instead)

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Under development or on the roadmap for development:
 - Open Vagrantfile in your favorite editor and review/edit the settings for your guest VM as needed (e.g. path to file system shares between the host and guest machines)
 - Open provisioning/playbook.yml in your favorite editor and review/edit the settings for your guest VM as needed
 - Next initialize and update the git submodules by running `git submodule init && git submodule update`, which will fetch the ansible-roles and client tools repositories
-- Export variable SMOKE_TESTS. This variable should be set to `kv` or `ts`. `export SMOKE_TESTS="kv"` or `export SMOKE_TESTS="ts"`
+- Export variable SMOKE_TESTS. This variable should be set to `kv` or `ts`. `export SMOKE_TESTS="kv"` or `export SMOKE_TESTS="ts"`. If not exported, defaults to `kv`
 - Run `vagrant up` to turn on your VM for the first time. It will automatically do the initial provisioning for the guest machine
 - After the machine has completed initial provisioning, login to it by running `vagrant ssh`
 - Once in the machine, run `ansible-playbook /vagrant/provisioning/playbook.yml` to install Riak (alternatively you can run timeseries.yml or security.yml to test TS or security instead)
@@ -43,10 +43,12 @@ Under development or on the roadmap for development:
 
 If you want to contribute to the Ansible Riak role, clone the repository to `provisioning/roles/basho-labs.riak-kv.dev` and `riak_testing_role_dev: true` to your playbook.yml. This will tell signal to the Ansible roles to use the local checkout for playbook execution instead of the latest release to Ansible Galaxy.
 
-# Running tests in parallel
+# Running tests in parallel with `multi-test.sh`
 - Open `multi-test.sh` and add your target vagrant boxes and Riak package URLs in the appropriate place
 - `export CT_GITHUB_TOKEN="put your github token here"`
-- `export SMOKE_TESTS="ts"` or `export SMOKE_TESTS="kv"`
+- `export SMOKE_TESTS="ts"` or `export SMOKE_TESTS="kv"`. If not exported, defaults to `kv`
 - `export CT_TEST_LIBS="['php', 'go', 'ruby', 'nodejs', 'java']"`
 - `export RIAK_TESTING_ROLE_DEV="true"`
-- `sh multi-test.sh`
+- `sh multi-test.sh run`
+- After running the tests, you can clean up with `sh multi-test.sh cleanup`. This will shutdown all VMs and delete their directories. This will leave the test results in `./results`
+- Run `sh multi-test.sh reset` to delete all VM's and testing directories, including the `./results`

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -70,7 +70,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  then executes /vagrant/provisioning/playbook.yml to provision your Guest.
   #   - This script is kicked off upon the initial "vagrant up" command issued on this vagrant instance
   #     and then only when the "vagrant provision" command is issued on this instance
-  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: ENV['SMOKE_TESTS']
+  smoketests = ENV['SMOKE_TESTS'] || 'kv'
+  extravars = ENV['EXTRA_VARS'] || ''
+  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: [smoketests,extravars]
 
   ##########################################################################
   # VirtualBox Guest Virtual Machine Configuaration

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -31,6 +31,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #config.vm.network :forwarded_port, guest: 22, host: 4545
 
   # Riak Ports - HTTP, HTTPS, PB
+  #   - Only needed if you want to access Riak from your host machine
   #config.vm.network :forwarded_port, guest: 8087, host: 8087
   #config.vm.network :forwarded_port, guest: 10011, host: 10011
   #config.vm.network :forwarded_port, guest: 8098, host: 8098
@@ -69,10 +70,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  then executes /vagrant/provisioning/playbook.yml to provision your Guest.
   #   - This script is kicked off upon the initial "vagrant up" command issued on this vagrant instance
   #     and then only when the "vagrant provision" command is issued on this instance
-
-  smoketests = ENV['SMOKE_TESTS'] || 'kv'
-  extravars = ENV['EXTRA_VARS'] || ''
-  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: [smoketests,extravars]
+  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: ENV['SMOKE_TESTS']
 
   ##########################################################################
   # VirtualBox Guest Virtual Machine Configuaration

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -69,7 +69,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  then executes /vagrant/provisioning/playbook.yml to provision your Guest.
   #   - This script is kicked off upon the initial "vagrant up" command issued on this vagrant instance
   #     and then only when the "vagrant provision" command is issued on this instance
-  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: [ENV['SMOKE_TESTS'], ENV['EXTRA_VARS']]
+  
+  smoketests = ENV['SMOKE_TESTS'] || ''
+  extravars = ENV['EXTRA_VARS'] || ''
+  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: [smoketests,extravars]
 
   ##########################################################################
   # VirtualBox Guest Virtual Machine Configuaration

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -31,9 +31,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #config.vm.network :forwarded_port, guest: 22, host: 4545
 
   # Riak Ports - HTTP, HTTPS, PB
-  config.vm.network :forwarded_port, guest: 8087, host: 8087
-  config.vm.network :forwarded_port, guest: 10011, host: 10011
-  config.vm.network :forwarded_port, guest: 8098, host: 8098
+  #config.vm.network :forwarded_port, guest: 8087, host: 8087
+  #config.vm.network :forwarded_port, guest: 10011, host: 10011
+  #config.vm.network :forwarded_port, guest: 8098, host: 8098
 
   # The following is useful if you want to make your VM accessible on the local network
   # You have to specify the static IP for the network and the NIC it will be using from the host machine.
@@ -69,7 +69,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  then executes /vagrant/provisioning/playbook.yml to provision your Guest.
   #   - This script is kicked off upon the initial "vagrant up" command issued on this vagrant instance
   #     and then only when the "vagrant provision" command is issued on this instance
-  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: "true"
+  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: ENV['SMOKE_TESTS']
 
   ##########################################################################
   # VirtualBox Guest Virtual Machine Configuaration

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -69,7 +69,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  then executes /vagrant/provisioning/playbook.yml to provision your Guest.
   #   - This script is kicked off upon the initial "vagrant up" command issued on this vagrant instance
   #     and then only when the "vagrant provision" command is issued on this instance
-  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: ENV['SMOKE_TESTS']
+  config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: [ENV['SMOKE_TESTS'], ENV['EXTRA_VARS']]
 
   ##########################################################################
   # VirtualBox Guest Virtual Machine Configuaration

--- a/Vagrantfile.template
+++ b/Vagrantfile.template
@@ -69,8 +69,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #  then executes /vagrant/provisioning/playbook.yml to provision your Guest.
   #   - This script is kicked off upon the initial "vagrant up" command issued on this vagrant instance
   #     and then only when the "vagrant provision" command is issued on this instance
-  
-  smoketests = ENV['SMOKE_TESTS'] || ''
+
+  smoketests = ENV['SMOKE_TESTS'] || 'kv'
   extravars = ENV['EXTRA_VARS'] || ''
   config.vm.provision "shell", path: "provisioning/bootstrap.sh", args: [smoketests,extravars]
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html>
+<body>
+
+<h1>Latest Client Smoke Testing Results:</h1>
+
+<h1>Riak TS EE 1.5.0rc3</h1>
+
+<h2>Ubuntu 16.04</h2>
+
+<h4>Log</h4>
+<object data="/results/ubuntu-16.04/log.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Ruby</h4>
+<object data="/results/ubuntu-16.04/ruby.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>PHP</h4>
+<object data="/results/ubuntu-16.04/php.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Go</h4>
+<object data="/results/ubuntu-16.04/go.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>NodeJS</h4>
+<object data="/results/ubuntu-16.04/nodejs.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Java</h4>
+<object data="/results/ubuntu-16.04/java.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h2>Ubuntu 14.04</h2>
+
+<h4>Log</h4>
+<object data="/results/ubuntu-14.04/log.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Ruby</h4>
+<object data="/results/ubuntu-14.04/ruby.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>PHP</h4>
+<object data="/results/ubuntu-14.04/php.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Go</h4>
+<object data="/results/ubuntu-14.04/go.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>NodeJS</h4>
+<object data="/results/ubuntu-14.04/nodejs.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Java</h4>
+<object data="/results/ubuntu-14.04/java.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h2>Centos 7.2</h2>
+
+<h4>Log</h4>
+<object data="/results/centos-7.2/log.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Ruby</h4>
+<object data="/results/centos-7.2/ruby.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>PHP</h4>
+<object data="/results/centos-7.2/php.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Go</h4>
+<object data="/results/centos-7.2/go.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>NodeJS</h4>
+<object data="/results/centos-7.2/nodejs.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Java</h4>
+<object data="/results/centos-7.2/java.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h2>Centos 6.7</h2>
+
+<h4>Log</h4>
+<object data="/results/centos-6.7/log.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Ruby</h4>
+<object data="/results/centos-6.7/ruby.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>PHP</h4>
+<object data="/results/centos-6.7//php.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Go</h4>
+<object data="/results/centos-6.7//go.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>NodeJS</h4>
+<object data="/results/centos-6.7//nodejs.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Java</h4>
+<object data="/results/centos-6.7//java.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h2>Debian 8.5</h2>
+
+<h4>Log</h4>
+<object data="/results/debian-8.5/log.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Ruby</h4>
+<object data="/results/debian-8.5/ruby.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>PHP</h4>
+<object data="/results/debian-8.5/php.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Go</h4>
+<object data="/results/debian-8.5/go.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>NodeJS</h4>
+<object data="/results/debian-8.5/nodejs.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Java</h4>
+<object data="/results/debian-8.5/java.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h2>Debian 7.8</h2>
+
+<h4>Log</h4>
+<object data="/results/debian-7.8/log.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Ruby</h4>
+<object data="/results/debian-7.8/ruby.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>PHP</h4>
+<object data="/results/debian-7.8/php.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Go</h4>
+<object data="/results/debian-7.8/go.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>NodeJS</h4>
+<object data="/results/debian-7.8/nodejs.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+<h4>Java</h4>
+<object data="/results/debian-7.8/java.txt" type="text/plain"
+width="800" style="height: 500px">
+</object>
+
+</body>
+</html>

--- a/multi-test.sh
+++ b/multi-test.sh
@@ -2,8 +2,7 @@
 
 # Setup variables
 tests="ts"
-#githubtoken="put you github token here"
-githubtoken="token"
+githubtoken="put you github token here"
 declare -a vmboxes=(
 						"vagrant box to use"
 					) 
@@ -45,7 +44,6 @@ do
 		sed -i ".bak" "s~#ct_github_token:~ct_github_token:~" ./parallel/vm$i/provisioning/playbook.yml
 		sed -i ".bak" "s~#riak_package:~riak_package:~" ./parallel/vm$i/provisioning/playbook.yml
 		sed -i ".bak" "s~#ct_test_libs:~ct_test_libs:~" ./parallel/vm$i/provisioning/playbook.yml
-		sed -i ".bak" "s~['php','go']~['$clients']~" ./parallel/vm$i/provisioning/playbook.yml
 	fi 
 	
 	if [[ "$tests" == *"ts"* ]]
@@ -58,6 +56,7 @@ do
 		sed -i ".bak" "s~#riak_testing_role_dev:~riak_testing_role_dev:~" ./parallel/vm$i/provisioning/timeseries.yml
 		sed -i ".bak" "s~#ct_github_token:~ct_github_token:~" ./parallel/vm$i/provisioning/timeseries.yml
 		sed -i ".bak" "s~#riak_package:~riak_package:~" ./parallel/vm$i/provisioning/timeseries.yml
+		sed -i ".bak" "s~#ct_test_libs:~ct_test_libs:~" ./parallel/vm$i/provisioning/playbook.yml
 	fi
 done
 
@@ -81,3 +80,4 @@ do
 	printf "VAGRANT_CWD=./parallel/vm$i/ vagrant destroy\n"
 	printf "cat ./parallel/vm$i/log$i.txt\n"
 done
+export SMOKE_TESTS=''

--- a/multi-test.sh
+++ b/multi-test.sh
@@ -2,25 +2,26 @@
 
 # Setup variables
 # Which flavor or Riak to test, kv or ts
-tests="kv"
 
 # List of vagrant boxes to use
 declare -a vmboxes=(
-            "vagrant boxes"
+            "put vagrant boxes here"
+            "put vagrant boxes here"
+            "put vagrant boxes here"
           ) 
 # List of riak package urls
 # Note: the position of the packages for a specific OS in this array should
 # correspond to the position of vagrant box in the previous array based on OS
 declare -a riakpackages=(
-              "url to riak packages"
+              "put package urls here"
+              "put package urls here"
+              "put package urls here"
               ) 
-# Your Github personal access token
-githubtoken="your github token"
 
-export SMOKE_TESTS=$tests
 numboxes=${#vmboxes[@]}
 mkdir parallel
 
+printf 'Running Tests...this could take awhile.\n'
 for (( i=1; i<${numboxes}+1; i++ ));
 do
   	# Clone riak-clients-vagrant for each OS
@@ -35,31 +36,21 @@ do
 	# Set OS in Vagrantfile
 	sed -i ".bak" "s~bento/centos-7.2~${vmboxes[$i-1]}~" ./parallel/vm$i/Vagrantfile
 
-	if [[ "$tests" == *"kv"* ]]
+	if [[ "$SMOKE_TESTS" == *"kv"* ]]
 	then
 		printf 'Setting up KV playbook\n'
 		playbook="playbook.yml"
 	fi 
 	
-	if [[ "$tests" == *"ts"* ]]
+	if [[ "$SMOKE_TESTS" == *"ts"* ]]
 	then
 		printf 'Setting up TS playbook\n'
 		playbook="timeseries.yml"
 	fi
 	# Configure playbook variables
 	package="${riakpackages[$i-1]}"
-	sed -i ".bak" "s~a_valid_package~'$package'~" ./parallel/vm$i/provisioning/$playbook
-	sed -i ".bak" "s~a_valid_token~'$githubtoken'~" ./parallel/vm$i/provisioning/$playbook
-	# Uncomment playbook lines
-	sed -i ".bak" "s~#riak_testing_role_dev:~riak_testing_role_dev:~" ./parallel/vm$i/provisioning/$playbook
-	sed -i ".bak" "s~#ct_github_token:~ct_github_token:~" ./parallel/vm$i/provisioning/$playbook
-	sed -i ".bak" "s~#riak_package:~riak_package:~" ./parallel/vm$i/provisioning/$playbook
-	sed -i ".bak" "s~#ct_test_libs:~ct_test_libs:~" ./parallel/vm$i/provisioning/$playbook
-done
+	export EXTRA_VARS="{'riak_package': '$package', 'ct_github_token': '$CT_GITHUB_TOKEN', 'ct_test_libs': $CT_TEST_LIBS, 'riak_testing_role_dev': '$RIAK_TESTING_ROLE_DEV'}"
 
-printf 'Running Tests...this could take awhile.\n'
-for (( i=1; i<${numboxes}+1; i++ ));
-do
 	if (( ${numboxes} == 1 ))
 	then
 		VAGRANT_CWD=./parallel/vm$i/ vagrant up &
@@ -67,6 +58,7 @@ do
 		VAGRANT_CWD=./parallel/vm$i/ vagrant up >./parallel/vm$i/log$i.txt 2>&1 &
 	fi
 done
+
 wait
 printf 'Tests Complete\n'
 printf "The VM's are still running\n"
@@ -77,4 +69,3 @@ do
 	printf "VAGRANT_CWD=./parallel/vm$i/ vagrant destroy\n"
 	printf "cat ./parallel/vm$i/log$i.txt\n"
 done
-export SMOKE_TESTS=''

--- a/multi-test.sh
+++ b/multi-test.sh
@@ -14,7 +14,7 @@ declare -a riakpackages=(
               "put package urls here"
               "put package urls here"
               "put package urls here"
-              ) 
+              )
 
 if [ -z ${CT_GITHUB_TOKEN+x} ]; then printf 'Variable CT_GITHUB_TOKEN not set. Exiting...' && exit; fi
 if [ -z ${SMOKE_TESTS+x} ]; then printf 'Variable SMOKE_TESTS not set. Exiting...' && exit; fi

--- a/multi-test.sh
+++ b/multi-test.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 # Setup variables
-# Which flavor or Riak to test, kv or ts
-
 # List of vagrant boxes to use
 declare -a vmboxes=(
             "put vagrant boxes here"
@@ -18,54 +16,132 @@ declare -a riakpackages=(
               "put package urls here"
               ) 
 
+if [ -z ${CT_GITHUB_TOKEN+x} ]; then printf 'Variable CT_GITHUB_TOKEN not set. Exiting...' && exit; fi
+if [ -z ${SMOKE_TESTS+x} ]; then printf 'Variable SMOKE_TESTS not set. Exiting...' && exit; fi
+if [ -z ${CT_TEST_LIBS+x} ]; then printf 'Variable CT_TEST_LIBS not set. Exiting...' && exit; fi
+if [ -z ${RIAK_TESTING_ROLE_DEV+x} ]; then printf 'Variable RIAK_TESTING_ROLE_DEV not set. Exiting...' && exit; fi
+
 numboxes=${#vmboxes[@]}
+numpackages=${#riakpackages[@]}
+
+if (( ${numboxes} == 0 )); then printf 'No VMs specified. Exiting...' && exit; fi
+if (( ${numpackages} == 0 )); then printf 'No Riak packages specified. Exiting...' && exit; fi	
+if (( ${numpackages} != ${numboxes})); then printf 'There should be one VM declared for each Riak package. Exiting...' && exit; fi	
+
+if [[ "$1" == "run" ]]
+then 
+	printf 'Running Tests...this could take awhile.\n'
+elif [[ "$1" == "cleanup" ]]
+then 
+	for i in $(ls -d ./parallel/*/)
+	do
+		VAGRANT_CWD=${i} vagrant destroy --force &
+	done
+	wait
+
+	rm -rf ./parallel
+	exit
+elif [[ "$1" == "reset" ]]
+then
+	for i in $(ls -d ./parallel/*/)
+	do 
+		VAGRANT_CWD=${i} vagrant destroy --force &
+	done
+	wait
+
+	rm -rf ./parallel
+	rm -rf results
+	exit
+else
+	printf 'Aborting. No command selected.\n'
+	printf 'Your options are: run, cleanup, reset.\n'
+	exit
+fi
+
 mkdir parallel
 
-printf 'Running Tests...this could take awhile.\n'
 for (( i=1; i<${numboxes}+1; i++ ));
 do
-  	# Clone riak-clients-vagrant for each OS
-	rsync -av --exclude='parallel' ./ ./parallel/vm$i
-	cp ./parallel/vm$i/Vagrantfile.template ./parallel/vm$i/Vagrantfile && cp ./parallel/vm$i/provisioning/playbook.yml.template ./parallel/vm$i/provisioning/playbook.yml
-	(cd ./parallel/vm$i/ && git submodule init && git submodule update)
+  	printf 'Clone riak-clients-vagrant repo for each target VM \n'
+	rsync -av --exclude="parallel" --exclude=".*" --exclude ".*/" ./ ./parallel/vm${i} >/dev/null 2>&1
+	cp ./parallel/vm${i}/Vagrantfile.template ./parallel/vm${i}/Vagrantfile && cp ./parallel/vm${i}/provisioning/playbook.yml.template ./parallel/vm${i}/provisioning/playbook.yml
+	(cd ./parallel/vm${i}/ && git submodule init && git submodule update)
 
-	# Modify Vagrantfile v.name
+
+	printf 'Setting Vagrantfile v.name \n'
 	vname="vagrant-riak-clients-$i"
-	sed -i ".bak" "s~vagrant-riak-clients~$vname~" ./parallel/vm$i/Vagrantfile
+	sed -i ".bak" "s~vagrant-riak-clients~vagrant-riak-clients-${i}~" ./parallel/vm${i}/Vagrantfile
 
-	# Set OS in Vagrantfile
-	sed -i ".bak" "s~bento/centos-7.2~${vmboxes[$i-1]}~" ./parallel/vm$i/Vagrantfile
+	printf 'Setting Vagrantfile config.vm.box \n'
+	sed -i ".bak" "s~bento/centos-7.2~${vmboxes[$i-1]}~" ./parallel/vm${i}/Vagrantfile
 
-	if [[ "$SMOKE_TESTS" == *"kv"* ]]
+	if [[ "$SMOKE_TESTS" == "kv" ]]
 	then
 		printf 'Setting up KV playbook\n'
 		playbook="playbook.yml"
-	fi 
-	
-	if [[ "$SMOKE_TESTS" == *"ts"* ]]
+	elif [[ "$SMOKE_TESTS" == "ts" ]]
 	then
 		printf 'Setting up TS playbook\n'
 		playbook="timeseries.yml"
+	else
+		printf 'Unrecognized test suite selected...\n'
+		printf 'Please export SMOKE_TESTS="kv" or export SMOKE_TESTS="ts" and re-run this script...\n'
+		rm -rf parallel
+		exit
 	fi
 	# Configure playbook variables
 	package="${riakpackages[$i-1]}"
 	export EXTRA_VARS="{'riak_package': '$package', 'ct_github_token': '$CT_GITHUB_TOKEN', 'ct_test_libs': $CT_TEST_LIBS, 'riak_testing_role_dev': '$RIAK_TESTING_ROLE_DEV'}"
-
+	printf "EXTRA_VARS='${EXTRA_VARS}' \n"
 	if (( ${numboxes} == 1 ))
 	then
-		VAGRANT_CWD=./parallel/vm$i/ vagrant up &
+		VAGRANT_CWD=./parallel/vm${i}/ vagrant up &
 	else
-		VAGRANT_CWD=./parallel/vm$i/ vagrant up >./parallel/vm$i/log$i.txt 2>&1 &
+		VAGRANT_CWD=./parallel/vm${i}/ vagrant up >./parallel/vm${i}/log.txt 2>&1 &
+	fi
+done
+printf "Waiting for VM's to come up and tests to finish... \n"
+wait
+printf "Smoke testing complete... \n"
+printf "Gathering test results... \n"
+
+for (( i=1; i<${numboxes}+1; i++ ));
+do
+	printf "Grabbing logs from within VM${i}... \n"
+	VAGRANT_CWD=./parallel/vm${i}/ vagrant ssh -- 'if [ -e /var/log/client_smoke_tests ]; then cp -R /var/log/client_smoke_tests /vagrant/test_logs; fi' &
+done
+wait
+
+printf "Gathering results... \n"
+rm -rf ./results
+mkdir ./results
+
+for (( i=1; i<${numboxes}+1; i++ ));
+do
+	box="${vmboxes[$i-1]}"
+	prefixbox=${box////-}
+	if [ -e ./parallel/vm${i}/test_logs ]
+	then 
+		cp -R ./parallel/vm${i}/test_logs ./results/${prefixbox}_vm${i}_test_logs
+		cp ./parallel/vm${i}/log.txt ./results/${prefixbox}_vm${i}_test_logs/log.txt
 	fi
 done
 
-wait
-printf 'Tests Complete\n'
-printf "The VM's are still running\n"
-printf "Some useful commands:\n"
+printf "All done... \n"
+printf "The VM's are still running...\n"
+printf "Some useful commands: \n"
 for (( i=1; i<${numboxes}+1; i++ ));
 do
-	printf "VAGRANT_CWD=./parallel/vm$i/ vagrant ssh\n"
-	printf "VAGRANT_CWD=./parallel/vm$i/ vagrant destroy\n"
-	printf "cat ./parallel/vm$i/log$i.txt\n"
+	printf "###################################################################\n"
+	printf "VAGRANT_CWD=./parallel/vm${i}/ vagrant ssh\n"
+	printf "VAGRANT_CWD=./parallel/vm${i}/ vagrant destroy\n"
+	box="${vmboxes[$i-1]}"
+	prefixbox=${box////-}
+	printf "**** ${prefixbox}'s test reuslts: ./results/${prefixbox}_vm${i}_test_logs **** \n"
+	for j in $(ls ./results/${prefixbox}_vm${i}_test_logs); do printf "${j} \n"; done
+	printf "###################################################################\n"
 done
+
+printf "Run sh multi-test.sh cleanup to remove all the VM's and keep ./results \n"
+printf "Run sh multi-test.sh reset to remove all the VM's and ./results \n"
+

--- a/multi-test.sh
+++ b/multi-test.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Setup variables
+tests="ts"
+#githubtoken="put you github token here"
+githubtoken="token"
+declare -a vmboxes=(
+						"vagrant box to use"
+					) 
+
+declare -a kvosspackages=(
+							"url to riak kv package"
+						  ) 
+
+declare -a tsosspackages=(
+							"url to riak ts package"
+						  ) 
+
+export SMOKE_TESTS=$tests
+numboxes=${#vmboxes[@]}
+mkdir parallel
+
+for (( i=1; i<${numboxes}+1; i++ ));
+do
+  	# Clone riak-clients-vagrant for each OS
+	rsync -av --exclude='parallel' ./ ./parallel/vm$i
+	cp ./parallel/vm$i/Vagrantfile.template ./parallel/vm$i/Vagrantfile && cp ./parallel/vm$i/provisioning/playbook.yml.template ./parallel/vm$i/provisioning/playbook.yml
+	(cd ./parallel/vm$i/ && git submodule init && git submodule update)
+
+	# Modify Vagrantfile v.name
+	vname="vagrant-riak-clients-$i"
+	sed -i ".bak" "s~vagrant-riak-clients~$vname~" ./parallel/vm$i/Vagrantfile
+
+	# Set OS in Vagrantfile
+	sed -i ".bak" "s~bento/centos-7.2~${vmboxes[$i-1]}~" ./parallel/vm$i/Vagrantfile
+
+	if [[ "$tests" == *"kv"* ]]
+	then
+		# Set variables in playbook.yml
+		printf 'Setting up KV playbook\n'
+		package="${kvosspackages[$i-1]}"
+		sed -i ".bak" "s~a_valid_package~'$package'~" ./parallel/vm$i/provisioning/playbook.yml
+		sed -i ".bak" "s~a_valid_token~'$githubtoken'~" ./parallel/vm$i/provisioning/playbook.yml
+		sed -i ".bak" "s~#riak_testing_role_dev:~riak_testing_role_dev:~" ./parallel/vm$i/provisioning/playbook.yml
+		sed -i ".bak" "s~#ct_github_token:~ct_github_token:~" ./parallel/vm$i/provisioning/playbook.yml
+		sed -i ".bak" "s~#riak_package:~riak_package:~" ./parallel/vm$i/provisioning/playbook.yml
+		sed -i ".bak" "s~#ct_test_libs:~ct_test_libs:~" ./parallel/vm$i/provisioning/playbook.yml
+		sed -i ".bak" "s~['php','go']~['$clients']~" ./parallel/vm$i/provisioning/playbook.yml
+	fi 
+	
+	if [[ "$tests" == *"ts"* ]]
+	then
+		# Set variables in timeseries.yml
+		printf 'Setting up TS playbook\n'
+		package="${tsosspackages[$i-1]}"
+		sed -i ".bak" "s~a_valid_package~'$package'~" ./parallel/vm$i/provisioning/timeseries.yml
+		sed -i ".bak" "s~a_valid_token~'$githubtoken'~" ./parallel/vm$i/provisioning/timeseries.yml
+		sed -i ".bak" "s~#riak_testing_role_dev:~riak_testing_role_dev:~" ./parallel/vm$i/provisioning/timeseries.yml
+		sed -i ".bak" "s~#ct_github_token:~ct_github_token:~" ./parallel/vm$i/provisioning/timeseries.yml
+		sed -i ".bak" "s~#riak_package:~riak_package:~" ./parallel/vm$i/provisioning/timeseries.yml
+	fi
+done
+
+for (( i=1; i<${numboxes}+1; i++ ));
+do
+	printf 'Running Tests...this could take awhile.\n'
+	if (( ${numboxes} == 1 ))
+	then
+		VAGRANT_CWD=./parallel/vm$i/ vagrant up &
+	else
+		VAGRANT_CWD=./parallel/vm$i/ vagrant up >./parallel/vm$i/log$i.txt 2>&1 &
+	fi
+done
+wait
+printf 'Tests Complete\n'
+printf "The VM's are still running\n"
+printf "Some useful commands:\n"
+for (( i=1; i<${numboxes}+1; i++ ));
+do
+	printf "VAGRANT_CWD=./parallel/vm$i/ vagrant ssh\n"
+	printf "VAGRANT_CWD=./parallel/vm$i/ vagrant destroy\n"
+	printf "cat ./parallel/vm$i/log$i.txt\n"
+done

--- a/multi-test.sh
+++ b/multi-test.sh
@@ -2,6 +2,12 @@
 
 # Setup variables
 # List of vagrant boxes to use
+			#"bento/ubuntu-16.04"
+            #"bento/debian-8.5"
+            #"bento/centos-7.2"
+            #"bento/ubuntu-14.04"
+            #"bento/debian-7.8"
+            #"bento/centos-6.7"
 declare -a vmboxes=(
             "put vagrant boxes here"
             "put vagrant boxes here"
@@ -20,6 +26,7 @@ if [ -z ${CT_GITHUB_TOKEN+x} ]; then printf 'Variable CT_GITHUB_TOKEN not set. E
 if [ -z ${SMOKE_TESTS+x} ]; then printf 'Variable SMOKE_TESTS not set. Exiting...' && exit; fi
 if [ -z ${CT_TEST_LIBS+x} ]; then printf 'Variable CT_TEST_LIBS not set. Exiting...' && exit; fi
 if [ -z ${RIAK_TESTING_ROLE_DEV+x} ]; then printf 'Variable RIAK_TESTING_ROLE_DEV not set. Exiting...' && exit; fi
+if [ -z ${CONCURRENCY_LIMIT+x} ]; then printf 'Variable CONCURRENCY_LIMIT not set. Exiting...' && exit; fi
 
 numboxes=${#vmboxes[@]}
 numpackages=${#riakpackages[@]}
@@ -59,6 +66,7 @@ else
 fi
 
 mkdir parallel
+mkdir results
 
 for (( i=1; i<${numboxes}+1; i++ ));
 do
@@ -66,7 +74,6 @@ do
 	rsync -av --exclude="parallel" --exclude=".*" --exclude ".*/" ./ ./parallel/vm${i} >/dev/null 2>&1
 	cp ./parallel/vm${i}/Vagrantfile.template ./parallel/vm${i}/Vagrantfile && cp ./parallel/vm${i}/provisioning/playbook.yml.template ./parallel/vm${i}/provisioning/playbook.yml
 	(cd ./parallel/vm${i}/ && git submodule init && git submodule update)
-
 
 	printf 'Setting Vagrantfile v.name \n'
 	vname="vagrant-riak-clients-$i"
@@ -89,59 +96,73 @@ do
 		rm -rf parallel
 		exit
 	fi
-	# Configure playbook variables
+
 	package="${riakpackages[$i-1]}"
 	export EXTRA_VARS="{'riak_package': '$package', 'ct_github_token': '$CT_GITHUB_TOKEN', 'ct_test_libs': $CT_TEST_LIBS, 'riak_testing_role_dev': '$RIAK_TESTING_ROLE_DEV'}"
 	printf "EXTRA_VARS='${EXTRA_VARS}' \n"
 	if (( ${numboxes} == 1 ))
 	then
-		VAGRANT_CWD=./parallel/vm${i}/ vagrant up &
+		VAGRANT_CWD=./parallel/vm${i}/ vagrant up | tee ./parallel/vm${i}/log.txt &
 	else
 		VAGRANT_CWD=./parallel/vm${i}/ vagrant up >./parallel/vm${i}/log.txt 2>&1 &
 	fi
-done
-printf "Waiting for VM's to come up and tests to finish... \n"
-wait
-printf "Smoke testing complete... \n"
-printf "Gathering test results... \n"
+	if (( ${i} % ${CONCURRENCY_LIMIT} == 0 )) || (( ${i}  == ${numboxes} ))
+	then
+		printf "Concurrency limit reached...waiting for this batch to complete before running next batch..."
+    	wait
+    	printf "Batch complete... \n"
+		printf "Gathering test results... \n"
 
-for (( i=1; i<${numboxes}+1; i++ ));
-do
-	printf "Grabbing logs from within VM${i}... \n"
-	VAGRANT_CWD=./parallel/vm${i}/ vagrant ssh -- 'if [ -e /var/log/client_smoke_tests ]; then cp -R /var/log/client_smoke_tests /vagrant/test_logs; fi' &
-done
-wait
+		for (( j=1+$(( $(( (${i} - 1) / ${CONCURRENCY_LIMIT} )) * ${CONCURRENCY_LIMIT})); j<${i}+1; j++ ));
+		do
+			printf "Grabbing logs from within VM${j}... \n"
+			VAGRANT_CWD=./parallel/vm${j}/ vagrant ssh -- 'if [ -e /var/log/client_smoke_tests ]; then cp -R /var/log/client_smoke_tests /vagrant/test_logs; fi' &
+		done
+		wait
 
-printf "Gathering results... \n"
-rm -rf ./results
-mkdir ./results
+		for (( j=1+$(( $(( (${i} - 1) / ${CONCURRENCY_LIMIT} )) * ${CONCURRENCY_LIMIT})); j<${i}+1; j++ ));
+		do
+			printf "Suspending VM${j}... \n"
+			VAGRANT_CWD=./parallel/vm${j}/ vagrant suspend &
+		done
+		wait
 
-for (( i=1; i<${numboxes}+1; i++ ));
-do
-	box="${vmboxes[$i-1]}"
-	prefixbox=${box////-}
-	if [ -e ./parallel/vm${i}/test_logs ]
-	then 
-		cp -R ./parallel/vm${i}/test_logs ./results/${prefixbox}_vm${i}_test_logs
-		cp ./parallel/vm${i}/log.txt ./results/${prefixbox}_vm${i}_test_logs/log.txt
+		for (( j=1+$(( $(( (${i} - 1) / ${CONCURRENCY_LIMIT} )) * ${CONCURRENCY_LIMIT})); j<${i}+1; j++ ));
+		do
+			box="${vmboxes[$j-1]}"
+			prefixbox=${box////-}
+			prefixbox=${prefixbox#"bento-"}
+			if [ -e ./parallel/vm${j}/test_logs ]
+			then 
+				mkdir ./results/${prefixbox}
+				mv ./parallel/vm${j}/test_logs/* ./results/${prefixbox}
+				mv ./parallel/vm${j}/log.txt ./results/${prefixbox}/log.txt
+				mv ./results/${prefixbox}/ruby*.log ./results/${prefixbox}/ruby.txt >/dev/null 2>&1
+				mv ./results/${prefixbox}/java*.log ./results/${prefixbox}/java.txt >/dev/null 2>&1
+				mv ./results/${prefixbox}/nodejs*.log ./results/${prefixbox}/nodejs.txt >/dev/null 2>&1
+				mv ./results/${prefixbox}/php*.log ./results/${prefixbox}/php.txt >/dev/null 2>&1
+				mv ./results/${prefixbox}/go*.log ./results/${prefixbox}/go.txt >/dev/null 2>&1
+			fi
+		done
 	fi
 done
 
 printf "All done... \n"
-printf "The VM's are still running...\n"
+printf "The VM's are still suspended...\n"
 printf "Some useful commands: \n"
 for (( i=1; i<${numboxes}+1; i++ ));
 do
 	printf "###################################################################\n"
+	printf "VAGRANT_CWD=./parallel/vm${i}/ vagrant resume\n"
 	printf "VAGRANT_CWD=./parallel/vm${i}/ vagrant ssh\n"
 	printf "VAGRANT_CWD=./parallel/vm${i}/ vagrant destroy\n"
 	box="${vmboxes[$i-1]}"
 	prefixbox=${box////-}
-	printf "**** ${prefixbox}'s test reuslts: ./results/${prefixbox}_vm${i}_test_logs **** \n"
-	for j in $(ls ./results/${prefixbox}_vm${i}_test_logs); do printf "${j} \n"; done
+	prefixbox=${prefixbox#"bento-"}
+	printf "**** ${prefixbox}'s test reuslts: ./results/${prefixbox} **** \n"
+	for j in $(ls ./results/${prefixbox}); do printf "${j} \n"; done
 	printf "###################################################################\n"
 done
 
 printf "Run sh multi-test.sh cleanup to remove all the VM's and keep ./results \n"
 printf "Run sh multi-test.sh reset to remove all the VM's and ./results \n"
-

--- a/provisioning/bootstrap.sh
+++ b/provisioning/bootstrap.sh
@@ -39,19 +39,18 @@ printf '
 if [[ "$1" == *"kv"* ]]
 then
 	printf 'Running KV tests'
-    ansible-playbook /vagrant/provisioning/playbook.yml
-fi
-
-if [[ "$1" == *"ts"* ]]
+    ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars="${2}"
+elif [[ "$1" == *"ts"* ]]
 then
 	printf 'Running TS tests'
-    ansible-playbook /vagrant/provisioning/timeseries.yml
-fi
-
-if [[ "$1" == *"security"* ]]
+    ansible-playbook /vagrant/provisioning/timeseries.yml --extra-vars="${2}"
+elif [[ "$1" == *"security"* ]]
 then
 	printf 'Running Security tests'
-    ansible-playbook /vagrant/provisioning/security.yml
+    ansible-playbook /vagrant/provisioning/security.yml --extra-vars="${2}"
+else
+	printf 'Defaulting to running KV tests'
+    ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars="${2}"
 fi
 
 printf '

--- a/provisioning/bootstrap.sh
+++ b/provisioning/bootstrap.sh
@@ -36,9 +36,22 @@ printf '
 ##                                                                                  ##
 ######################################################################################'
 
-if [ "$1" = "true" ]
+if [[ "$1" == *"kv"* ]]
 then
+	printf 'Running KV tests'
     ansible-playbook /vagrant/provisioning/playbook.yml
+fi
+
+if [[ "$1" == *"ts"* ]]
+then
+	printf 'Running TS tests'
+    ansible-playbook /vagrant/provisioning/timeseries.yml
+fi
+
+if [[ "$1" == *"security"* ]]
+then
+	printf 'Running Security tests'
+    ansible-playbook /vagrant/provisioning/security.yml
 fi
 
 printf '

--- a/provisioning/bootstrap.sh
+++ b/provisioning/bootstrap.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 printf '
 ######################################################################################
 ##                                                                                  ##
@@ -38,18 +37,22 @@ printf '
 
 if [[ "$1" == *"kv"* ]]
 then
-	printf 'Running KV tests'
+	printf 'Running KV tests \n'
+	printf "Running command: ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars="${2}"
 elif [[ "$1" == *"ts"* ]]
 then
-	printf 'Running TS tests'
+	printf 'Running TS tests \n'
+	printf "Running command: ansible-playbook /vagrant/provisioning/timeseries.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/timeseries.yml --extra-vars="${2}"
 elif [[ "$1" == *"security"* ]]
 then
-	printf 'Running Security tests'
+	printf 'Running Security tests \n'
+	printf "Running command: ansible-playbook /vagrant/provisioning/security.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/security.yml --extra-vars="${2}"
 else
-	printf 'Defaulting to running KV tests'
+	printf 'Defaulting to running KV tests \n'
+	printf "Running command: ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars="${2}"
 fi
 

--- a/provisioning/bootstrap.sh
+++ b/provisioning/bootstrap.sh
@@ -38,21 +38,17 @@ printf '
 if [[ "$1" == *"kv"* ]]
 then
 	printf 'Running KV tests \n'
-	printf "Running command: ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars="${2}"
 elif [[ "$1" == *"ts"* ]]
 then
 	printf 'Running TS tests \n'
-	printf "Running command: ansible-playbook /vagrant/provisioning/timeseries.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/timeseries.yml --extra-vars="${2}"
 elif [[ "$1" == *"security"* ]]
 then
 	printf 'Running Security tests \n'
-	printf "Running command: ansible-playbook /vagrant/provisioning/security.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/security.yml --extra-vars="${2}"
 else
 	printf 'Defaulting to running KV tests \n'
-	printf "Running command: ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars='${2}' \n"
     ansible-playbook /vagrant/provisioning/playbook.yml --extra-vars="${2}"
 fi
 

--- a/provisioning/playbook.yml.template
+++ b/provisioning/playbook.yml.template
@@ -32,7 +32,7 @@
     #   * use ct_test_libs to limit the execution of client languages to the supplied list
     - {
         role: basho-labs/client_smoke_tests,
-        #ct_test_libs: ['php','go']
+        #ct_test_libs: ['php','go', 'ruby', 'nodejs', 'java']
       }
   vars:
     # the vars section is used to pick the settings you want for your local environment
@@ -42,8 +42,9 @@
     #ct_github_token: a_valid_token
 
     # Uncomment following line to use alternate package. Options include URL to RPM or DEB, riak-ts, or a specific version from packagecloud.
-    #riak_package: 'https://s3.amazonaws.com/downloads.basho.com/basho-internal/riak/2.2/2.2.0rc4/rhel/7/riak-2.2.0rc4-1.el7.centos.x86_64.rpm'
-
+    #riak_package: a_valid_package
+    
+    #riak_testing_role_dev: true
     riak_search:  'on'
     riak_backend: 'multi'
     riak_pb_bind_ip: 127.0.0.1

--- a/provisioning/timeseries.yml
+++ b/provisioning/timeseries.yml
@@ -2,20 +2,31 @@
 - hosts: localhost
   become: true
   become_method: sudo
+  connection: local
   roles:
     - { role: common }
     - {
-        role: riak_testing,
+        role: basho-labs/riak_testing,
+        riak_conf_template: '/etc/ansible/roles/basho-labs/riak_testing/templates/riak.conf.j2',
         riak_node_name: "riak@127.0.0.1"
       }
-    - { role: client_smoke_tests }
+    - { role: basho-labs/client_smoke_tests,
+        #ct_test_libs: ['php','go', 'ruby', 'nodejs', 'java']
+      }
   vars:
-    riak_package: 'riak-ts'
-    #riak_package: 'riak-ts-1.3.1'
-    #riak_package: https://github.com/basho/internal_wiki/wiki/Riak-TS-1.4.0rc9-Release
+        # the vars section is used to pick the settings you want for your local environment
+    # see roles/{role_name}/defaults/main.yml for settings you can override
+
+    # GH Personal access token is needed to hit the GH API, see https://github.com/settings/tokens
+    #ct_github_token: a_valid_token
+
+    # Uncomment following line to use alternate package. Options include URL to RPM or DEB, riak-ts, or a specific version from packagecloud.
+    #riak_package: a_valid_package
+
+    #riak_testing_role_dev: true
     riak_shell_group: 'riak-ts'
     ct_cmd: cmdts
-
+   
     riak_search:  'on'
     riak_backend: 'leveldb'
     riak_pb_bind_ip: 127.0.0.1

--- a/provisioning/timeseries.yml
+++ b/provisioning/timeseries.yml
@@ -11,7 +11,7 @@
         riak_node_name: "riak@127.0.0.1"
       }
     - { role: basho-labs/client_smoke_tests,
-        #ct_test_libs: ['php','go', 'ruby', 'nodejs', 'java']
+        #ct_test_libs: ['php'] #'php','go', 'ruby', 'nodejs', 'java'
       }
   vars:
         # the vars section is used to pick the settings you want for your local environment
@@ -21,7 +21,7 @@
     #ct_github_token: a_valid_token
 
     # Uncomment following line to use alternate package. Options include URL to RPM or DEB, riak-ts, or a specific version from packagecloud.
-    #riak_package: a_valid_package
+    riak_package: riak-ts
 
     #riak_testing_role_dev: true
     riak_shell_group: 'riak-ts'


### PR DESCRIPTION
@christophermancini to test:

- clone branch
- open multi-test.sh and add your github token, the bento boxes, and the package urls you want to test in the appropriate places
- you can switch between ts and kv tests with the tests variable
- the vmboxes array and the packages array should be the same length... the positions of the elements must correspond to each other... i.e the if the first vmbox is "bento/centos-7.2" then the first package should be a centos7 package

if you run multi-test.sh with only one box/url combo, it will print to stdout, if you run for multiple box/url combos, it will print to a log file in each vm directory

currently there is a bunch of string replacement to configure the ansible playbook properly so maybe we could get strategic and have better strings to match on in the default playbooks

let me know what you think and if you have any suggestions